### PR TITLE
CI で利用している S3Proxy が list v2 に対応しておらず、integration test が失敗していたため、利用する…

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -56,6 +56,6 @@ services:
 
   # backup target (AWS S3 mock)
   s3proxy:
-    image: andrewgaul/s3proxy:travis-1232
+    image: andrewgaul/s3proxy:list-v2
     environment:
       - S3PROXY_AUTHORIZATION=none


### PR DESCRIPTION
… docker image を list-v2 へアップデート