### PR TITLE
Fix/e2e test fails by assert file exists on s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
 
     environment:
       DOCKER_COMPOSE_VER: 1.21.2
+      TZ: "Asia/Tokyo"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,11 @@ jobs:
       #   see. https://circleci.com/docs/2.0/docker-compose/
       - setup_remote_docker
 
+      # Match with the time zone of the mongodb-awesome-backup container.
+      - run:
+          name: Set timezone to Asia/Tokyo
+          command: cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+
       # Build and run integration test
       - run:
           name: Run integration tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
 
     environment:
       DOCKER_COMPOSE_VER: 1.21.2
-      # Next variable is needed to avoid to enter intaractive mode when install tzdata
+      # Disable interactive mode when running apt
       DEBIAN_FRONTEND: noninteractive
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,14 @@ jobs:
       #   see. https://circleci.com/docs/2.0/docker-compose/
       - setup_remote_docker
 
+      # For DEBUG
+      - run:
+          name: Display timezone
+          command: |
+            timedatectl
+
       # Build and run integration test
       - run:
           name: Run integration tests
           command: |
-            TZ=$TZ test/e2e.sh
+            test/e2e.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 jobs:
   build:
     docker:
+      # Match with the time zone of the mongodb-awesome-backup container.
       - image: ubuntu:bionic
-        # Match with the time zone of the mongodb-awesome-backup container.
         environment:
           TZ: "Asia/Tokyo"
 
@@ -51,11 +51,6 @@ jobs:
       # It is needed to activate the remote docker environment
       #   see. https://circleci.com/docs/2.0/docker-compose/
       - setup_remote_docker
-
-      # Match with the time zone of the mongodb-awesome-backup container.
-      - run:
-          name: Set timezone to Asia/Tokyo
-          command: cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
       # Build and run integration test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,11 @@ version: 2
 jobs:
   build:
     docker:
-      # Match with the time zone of the mongodb-awesome-backup container.
       - image: ubuntu:bionic
-        environment:
-          TZ: "Asia/Tokyo"
 
     environment:
       DOCKER_COMPOSE_VER: 1.21.2
-      TZ: "Asia/Tokyo"
+      # Next variable is needed to avoid to enter intaractive mode when install tzdata
       DEBIAN_FRONTEND: noninteractive
 
     steps:
@@ -50,32 +47,15 @@ jobs:
             curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VER}/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
 
+      # Match with the time zone of the mongodb-awesome-backup container.
       - run:
           name: set timezone to Asia/Tokyo
           command: |
             cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-      # For DEBUG
-      - run:
-          name: Display info
-          command: |
-            uname -a
-            cat /etc/*release
-            cat /etc/*version
-            #timedatectl
-
       # It is needed to activate the remote docker environment
       #   see. https://circleci.com/docs/2.0/docker-compose/
       - setup_remote_docker
-
-      # For DEBUG
-      - run:
-          name: Display info
-          command: |
-            uname -a
-            cat /etc/*release
-            cat /etc/*version
-            #timedatectl
 
       # Build and run integration test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,12 @@ jobs:
   build:
     docker:
       - image: ubuntu:bionic
+        # Match with the time zone of the mongodb-awesome-backup container.
+        environment:
+          TZ: "Asia/Tokyo"
 
     environment:
       DOCKER_COMPOSE_VER: 1.21.2
-      TZ: "Asia/Tokyo"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,4 +56,4 @@ jobs:
       - run:
           name: Run integration tests
           command: |
-            test/e2e.sh
+            TZ=$TZ test/e2e.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
 
     environment:
       DOCKER_COMPOSE_VER: 1.21.2
+      TZ: "Asia/Tokyo"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,8 @@ jobs:
               apt-transport-https \
               ca-certificates \
               curl \
-              software-properties-common
+              software-properties-common \
+              tzdata
 
       # Install docker client
       #   ref. https://docs.docker.com/install/linux/docker-ce/ubuntu/
@@ -48,13 +49,27 @@ jobs:
             curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VER}/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
 
+      - run:
+          name: set timezone to Asia/Tokyo
+          command: |
+            cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+
+      # For DEBUG
+      - run:
+          name: Display info
+          command: |
+            uname -a
+            cat /etc/*release
+            cat /etc/*version
+            #timedatectl
+
       # It is needed to activate the remote docker environment
       #   see. https://circleci.com/docs/2.0/docker-compose/
       - setup_remote_docker
 
       # For DEBUG
       - run:
-          name: Display timezone
+          name: Display info
           command: |
             uname -a
             cat /etc/*release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     environment:
       DOCKER_COMPOSE_VER: 1.21.2
       TZ: "Asia/Tokyo"
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,10 @@ jobs:
       - run:
           name: Display timezone
           command: |
-            timedatectl
+            uname -a
+            cat /etc/*release
+            cat /etc/*version
+            #timedatectl
 
       # Build and run integration test
       - run:

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -39,6 +39,8 @@ cd $CWD
 
 TODAY=`/bin/date +%Y%m%d` # It is used to generate file name to restore
 
+echo "=== $0 started at `/bin/date "+%Y/%m/%d %H:%M:%S"` ==="
+
 # Clean up before start s3proxy and mongodb
 docker-compose down -v
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -18,7 +18,13 @@ assert_file_exists_on_s3() {
 
   S3_FILE_PATH=$1
   docker-compose exec s3proxy sh -c "test -f /data/${S3_FILE_PATH}"
-  if [ $? -ne 0 ]; then echo 'assert_file_exists_on_s3 FAILED'; exit 1; fi
+  if [ $? -ne 0 ]; then
+    echo "assert_file_exists_on_s3 FAILED";
+    echo "could not be found /data/${S3_FILE_PATH} in s3proxy.";
+    echo "list of files under /data/"
+    docker-compose exec s3proxy sh -c "ls -alR /data/"
+    exit 1;
+  fi
 }
 
 # assert restore is successful


### PR DESCRIPTION
* e2e テスト実行時の TimeZone を Asia/Tokyo に指定
* assert_file_exists_on_s3 テストが失敗した時に、デバッグに有用な情報を出力するよう修正

関連して気が付いた下記の点は別途対応したいと思います。

* mab コンテナの default TimeZone が Asia/Tokyo であることを README.md へ記載する
* mab コンテナの TimeZone を変更する方法を検討して、その方法を README.md へ記載する
