### PR TITLE
cronmode で backup を実行した時にバックアップファイルを削除する処理を追加。ついでに cronmode で実行する時の R…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,7 @@ and after running this, `backup-YYYYMMdd.tar.bz2` will be placed on Target S3 Bu
 
 ### How to backup in cron mode
 
-1. modify crontab file
-  `$ vim crontab/root`
-1. confirm that the permission of "./crontab/root" is "root:root"
-1. execute docker container in cron mode
+Execute docker container with setting environment CRONMODE to "ture".
 
 ```bash
 docker run --rm \
@@ -59,7 +56,7 @@ docker run --rm \
   [ -e GCP_PROJECT_ID=<Your GCP Project ID> \ ]
   -e TARGET_BUCKET_URL=<Target Bucket URL ([s3://...|gs://...])> \
   -e CRONMODE=true \
-  -e CRON_EXPRESSION=<Cron expression (ex. "CRON_EXPRESSION=0 4 * * *" if you want to run at 4:00 every day)> \
+  -e CRON_EXPRESSION=<Cron expression (ex. "CRON_EXPRESSION='0 4 * * *'" if you want to run at 4:00 every day)> \
   [ -e BACKUPFILE_PREFIX=<Prefix of Backup Filename (default: "backup") \ ]
   [ -e MONGODB_HOST=<Target MongoDB Host (default: "mongo")> \ ]
   [ -e MONGODB_DBNAME=<Target DB name> \ ]

--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -3,6 +3,7 @@
 # settings
 BACKUPFILE_PREFIX=${BACKUPFILE_PREFIX:-backup}
 MONGODB_HOST=${MONGODB_HOST:-mongo}
+CRONMODE=${CRONMODE:-false}
 #MONGODB_HOST=
 #MONGODB_DBNAME=
 #MONGODB_USERNAME=
@@ -68,3 +69,8 @@ elif [ `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then
   gs_copy_file ${TARBALL_FULLPATH} ${TARGET_BUCKET_URL}${TARBALL}
 fi
 
+# clean up working files if in cron mode
+if ${CRONMODE} ; then
+  rm -rf ${TARGET}
+  rm -f ${TARBALL_FULLPATH}
+fi


### PR DESCRIPTION
…EADME 内容に誤りがあったため修正。

### 実装内容

* cron mode で backup.sh を実行した時に mongodump ディレクトリと tar 圧縮ファイルが残存する問題を解決
* README.md に書かれた cron mode で実行する方法に誤りがあったため修正

また、実装方針を話した際に、cleanup.sh を作成して cron mode の時のみ実行するよう修正する案がありましたが、下記理由で却下しました。

* TODAY 変数の値を backup.sh, cleanup.sh それぞれで代入することになりバックアップが日を跨いで実行される場合に値が変わる可能性を考慮しないといけないためシンプルではない
* cron mode で実行するコマンドは docker run の COMMANDS として受け取っているため、その中に backup が存在する場合だけ cleanup を追加する等、処理が少し複雑になる

### cron mode での backup.sh 実行ログ(変更箇所のみ抜粋)

```
  : <snip>
+ '[' s3 == s3 ']'
+ s3_copy_file /tmp/backup-20190407.tar.bz2 s3://temp-mab/backup-20190407.tar.bz2
+ '[' 2 -ne 2 ']'
+ /usr/bin/aws s3 cp /tmp/backup-20190407.tar.bz2 s3://temp-mab/backup-20190407.tar.bz2
upload: ../../tmp/backup-20190407.tar.bz2 to s3://temp-mab/backup-20190407.tar.bz2
+ true
+ rm -rf /tmp/mongodump
+ rm -f /tmp/backup-20190407.tar.bz2
There are files below in S3 bucket:
2019-04-07 03:56:03       1374 backup-20190407.tar.bz2
```

### 非 cron mode での backup.sh 実行ログ(変更箇所のみ抜粋)

```
  : <snip>
+ '[' s3 == s3 ']'
+ s3_copy_file /tmp/backup-20190407.tar.bz2 s3://temp-mab/backup-20190407.tar.bz2
+ '[' 2 -ne 2 ']'
+ /usr/bin/aws s3 cp /tmp/backup-20190407.tar.bz2 s3://temp-mab/backup-20190407.tar.bz2
upload: ../../tmp/backup-20190407.tar.bz2 to s3://temp-mab/backup-20190407.tar.bz2
+ false
There are files below in S3 bucket:
2019-04-07 03:54:50       1375 backup-20190407.tar.bz2

```