### PR TITLE
fix parsing environment value "TARGET_BUCKET_URL"

### DIFF
--- a/bin/boto.sh
+++ b/bin/boto.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-if [ ! `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then
+if [ "`echo $TARGET_BUCKET_URL | cut -f1 -d':'`" != "gs" ]; then
 	exit 0
 fi
 


### PR DESCRIPTION
元の if だと、環境変数が設定されていない、空白文字のときに if の中に入らず、 `hoge` という文字が出ない。(=想定外の挙動)
```
bash-4.4# export TARGET_BUCKET_URL=
bash-4.4# if [ ! `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then echo 'hoge'; fi
bash-4.4# export TARGET_BUCKET_URL=hoge:
bash-4.4# if [ ! `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then echo 'hoge'; fi
hoge
bash-4.4# export TARGET_BUCKET_URL=gs:
bash-4.4# if [ ! `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then echo 'hoge'; fi
bash-4.4# unset TARGET_BUCKET_URL
bash-4.4# if [ ! `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then echo 'hoge'; fi
```
修正後の if は、想定通りの挙動になる。
```
bash-4.4# export TARGET_BUCKET_URL=
bash-4.4# if [ "`echo $TARGET_BUCKET_URL | cut -f1 -d':'`" != "gs" ]; then echo 'hoge'; fi
hoge
bash-4.4# export TARGET_BUCKET_URL=hoge:
bash-4.4# if [ "`echo $TARGET_BUCKET_URL | cut -f1 -d':'`" != "gs" ]; then echo 'hoge'; fi
hoge
bash-4.4# export TARGET_BUCKET_URL=gs:
bash-4.4# if [ "`echo $TARGET_BUCKET_URL | cut -f1 -d':'`" != "gs" ]; then echo 'hoge'; fi
bash-4.4# unset TARGET_BUCKET_URL
bash-4.4# if [ "`echo $TARGET_BUCKET_URL | cut -f1 -d':'`" != "gs" ]; then echo 'hoge'; fi
hoge
```
