### PR TITLE
Improvement: remove the destination filename

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -64,9 +64,9 @@ time ${TAR_CMD} ${TAR_OPTS} ${TARBALL_FULLPATH} -C ${DIRNAME} ${BASENAME}
 
 if [ `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "s3" ]; then
   # transfer tarball to Amazon S3
-  s3_copy_file ${TARBALL_FULLPATH} ${TARGET_BUCKET_URL}${TARBALL}
+  s3_copy_file ${TARBALL_FULLPATH} ${TARGET_BUCKET_URL}
 elif [ `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then
-  gs_copy_file ${TARBALL_FULLPATH} ${TARGET_BUCKET_URL}${TARBALL}
+  gs_copy_file ${TARBALL_FULLPATH} ${TARGET_BUCKET_URL}
 fi
 
 # clean up working files if in cron mode

--- a/bin/restore.sh
+++ b/bin/restore.sh
@@ -21,9 +21,7 @@ TAR_OPTS="jxvf"
 DIRNAME=`/usr/bin/dirname ${TARGET}`
 BASENAME=`/usr/bin/basename ${TARGET}`
 TARBALL_FULLPATH="${TMPDIR}/${TARGET_FILE}"
-
-S3_TARBALL_FULLURL=${TARGET_BUCKET_URL}${TARGET_FILE}
-GS_TARBALL_FULLURL=${TARGET_BUCKET_URL}${TARGET_FILE}
+TARBALL_FULLURL=${TARGET_BUCKET_URL}${TARGET_FILE}
 
 # check parameters
 if [ "x${TARGET_BUCKET_URL}" == "x" ]; then
@@ -37,9 +35,9 @@ fi
 
 if [ `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "s3" ]; then
   # download tarball from Amazon S3
-  s3_copy_file ${S3_TARBALL_FULLURL} ${TARBALL_FULLPATH}
+  s3_copy_file ${TARBALL_FULLURL} ${TARBALL_FULLPATH}
 elif [ `echo $TARGET_BUCKET_URL | cut -f1 -d":"` == "gs" ]; then
-  gs_copy_file ${GS_TARBALL_FULLURL} ${TARBALL_FULLPATH}
+  gs_copy_file ${TARBALL_FULLURL} ${TARBALL_FULLPATH}
 fi
 
 # run tar command


### PR DESCRIPTION
GCS でバックアップがしたいだけなのに、`storage.objects.list` 権限が必要と言われたので修正。
GCS/S3 共にファイル名なしで cp が動くことを確認済み。