### PR TITLE
fix/release-action-fail-because-built-image-not-found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,7 @@ jobs:
           --tag ${DOCKERHUB_REPOSITORY}
           --platform linux/amd64
           --cache-from type=registry,ref=${DOCKERHUB_REPOSITORY}
-          --cache-to type=inline
-          --push
+          --load
           .
 
       - name: Tagging Docker Image by SemVer and publish


### PR DESCRIPTION
This PR fix `release` action on GitHub Actions.