### PR TITLE
Custom s3 endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ What is mongodb-awesome-backup?
 -------------------------------
 
 mongodb-awesome-backup is the collection of scripts which backup MongoDB databases to Amazon S3 or Google Cloud Storage.
+You can set a custom s3 endpoint to use s3 based services like DigitalOcean Spaces instead of Amazon S3.
 
 
 Requirements
@@ -124,6 +125,7 @@ Environment variables
 | MONGODB_AUTHDB                    | Authentication DB name                                                                                                                                                        | -        |
 | CRONMODE                          | If set "true", this container is executed in cron mode.  In cron mode, the script will be executed with the specified arguments and at the time specified by CRON_EXPRESSION. | "false"  |
 | CRON_EXPRESSION                   | Cron expression (ex. "CRON_EXPRESSION=0 4 * * *" if you want to run at 4:00 every day)                                                                                        | -        |
+| AWSCLI_ENDPOINT_URL_OPTION        | Set a custom s3 endpoint if you use a s3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_URL_OPTION="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |
 | HEALTHCHECKS_URL                  | URL that gets called after a successful backup (eg. https://healthchecks.io)                                                                                                  | -        |
 
 ### For `restore`
@@ -151,3 +153,4 @@ Environment variables
 | MONGODB_PASSWORD                  | DB login password                              | -       |
 | MONGODB_AUTHDB                    | Authentication DB name                         | -       |
 | MONGORESTORE_OPTS                 | Options list of mongorestore. (ex --drop)      | -       |
+| AWSCLI_ENDPOINT_URL_OPTION        | Set a custom s3 endpoint if you use a s3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_URL_OPTION="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ What is mongodb-awesome-backup?
 -------------------------------
 
 mongodb-awesome-backup is the collection of scripts which backup MongoDB databases to Amazon S3 or Google Cloud Storage.
-You can set a custom s3 endpoint to use s3 based services like DigitalOcean Spaces instead of Amazon S3.
+You can set a custom S3 endpoint to use S3 based services like DigitalOcean Spaces instead of Amazon S3.
 
 
 Requirements
@@ -125,7 +125,7 @@ Environment variables
 | MONGODB_AUTHDB                    | Authentication DB name                                                                                                                                                        | -        |
 | CRONMODE                          | If set "true", this container is executed in cron mode.  In cron mode, the script will be executed with the specified arguments and at the time specified by CRON_EXPRESSION. | "false"  |
 | CRON_EXPRESSION                   | Cron expression (ex. "CRON_EXPRESSION=0 4 * * *" if you want to run at 4:00 every day)                                                                                        | -        |
-| AWSCLI_ENDPOINT_URL_OPTION        | Set a custom s3 endpoint if you use a s3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_URL_OPTION="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |
+| AWSCLI_ENDPOINT_OPT               | Set a custom S3 endpoint if you use a S3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_OPT="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |
 | HEALTHCHECKS_URL                  | URL that gets called after a successful backup (eg. https://healthchecks.io)                                                                                                  | -        |
 
 ### For `restore`
@@ -153,4 +153,4 @@ Environment variables
 | MONGODB_PASSWORD                  | DB login password                              | -       |
 | MONGODB_AUTHDB                    | Authentication DB name                         | -       |
 | MONGORESTORE_OPTS                 | Options list of mongorestore. (ex --drop)      | -       |
-| AWSCLI_ENDPOINT_URL_OPTION        | Set a custom s3 endpoint if you use a s3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_URL_OPTION="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |
+| AWSCLI_ENDPOINT_OPT               | Set a custom S3 endpoint if you use a S3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_OPT="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ docker run --rm \
   [ -e MONGODB_USERNAME=<DB login username> \ ]
   [ -e MONGODB_PASSWORD=<DB login password> \ ]
   [ -e MONGODB_AUTHDB=<Authentication DB name> \ ]
+  [ -e AWSCLI_ENDPOINT_OPT=<S3 endpoint URL (ex. https://fra1.digitaloceanspaces.com)> \ ]
   [ -v ~:/mab \ ]
   weseek/mongodb-awesome-backup
 ```
@@ -67,6 +68,7 @@ docker run --rm \
   [ -e MONGODB_USERNAME=<DB login username> \ ]
   [ -e MONGODB_PASSWORD=<DB login password> \ ]
   [ -e MONGODB_AUTHDB=<Authentication DB name> \ ]
+  [ -e AWSCLI_ENDPOINT_OPT=<S3 endpoint URL (ex. https://fra1.digitaloceanspaces.com)> \ ]
   [ -v ~:/mab \ ]
   weseek/mongodb-awesome-backup
 ```
@@ -91,6 +93,7 @@ docker run --rm \
   [ -e MONGODB_PASSWORD=<DB login password> \ ]
   [ -e MONGODB_AUTHDB=<Authentication DB name> \ ] 
   [ -e MONGORESTORE_OPTS=<Options list of mongorestore> \ ]
+  [ -e AWSCLI_ENDPOINT_OPT=<S3 endpoint URL (ex. https://fra1.digitaloceanspaces.com)> \ ]
   [ -v ~:/mab \ ]
   weseek/mongodb-awesome-backup restore
 ```
@@ -125,7 +128,7 @@ Environment variables
 | MONGODB_AUTHDB                    | Authentication DB name                                                                                                                                                        | -        |
 | CRONMODE                          | If set "true", this container is executed in cron mode.  In cron mode, the script will be executed with the specified arguments and at the time specified by CRON_EXPRESSION. | "false"  |
 | CRON_EXPRESSION                   | Cron expression (ex. "CRON_EXPRESSION=0 4 * * *" if you want to run at 4:00 every day)                                                                                        | -        |
-| AWSCLI_ENDPOINT_OPT               | Set a custom S3 endpoint if you use a S3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_OPT="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |
+| AWSCLI_ENDPOINT_OPT               | Set a custom S3 endpoint if you use a S3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_OPT="https://fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |
 | HEALTHCHECKS_URL                  | URL that gets called after a successful backup (eg. https://healthchecks.io)                                                                                                  | -        |
 
 ### For `restore`
@@ -153,4 +156,4 @@ Environment variables
 | MONGODB_PASSWORD                  | DB login password                              | -       |
 | MONGODB_AUTHDB                    | Authentication DB name                         | -       |
 | MONGORESTORE_OPTS                 | Options list of mongorestore. (ex --drop)      | -       |
-| AWSCLI_ENDPOINT_OPT               | Set a custom S3 endpoint if you use a S3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_OPT="fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |
+| AWSCLI_ENDPOINT_OPT               | Set a custom S3 endpoint if you use a S3 based service like DigitalOcean Spaces. (ex. AWSCLI_ENDPOINT_OPT="https://fra1.digitaloceanspaces.com") If not set the Amazon S3 standard endpoint will be used. | -        |

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -1,6 +1,6 @@
 # default settings
 AWSCLI="/usr/bin/aws"
-#AWSCLI_ENDPOINT_URL_OPTION="--endpoint-url <YourEndpointUrl>"
+#AWSCLI_ENDPOINT_OPT="--endpoint-url <YourEndpointUrl>"
 AWSCLI_COPY_OPT="s3 cp"
 AWSCLI_LIST_OPT="s3 ls"
 AWSCLI_DEL_OPT="s3 rm"
@@ -20,7 +20,7 @@ DATE_CMD="/bin/date"
 # arguments: 1. s3 url (s3://.../...)
 s3_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
-	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
+	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
 }
 gs_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -30,7 +30,7 @@ gs_exists() {
 # Output the list of the files on specified S3 URL.
 # arguments: 1. s3 url (s3://...)
 s3_list_files() {
-	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
+	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
 }
 gs_list_files() {
 	${GCSCLI} ${GCSCLIOPT} ${GCSCLI_LIST_OPT} $1
@@ -40,7 +40,7 @@ gs_list_files() {
 # arguments: 1. s3 url (s3://.../...)
 s3_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
-	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
+	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
 }
 gs_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -58,7 +58,7 @@ gs_delete_file() {
 #            2. target s3 url (s3://...)
 s3_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi
-	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
+	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
 }
 gs_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -4,6 +4,7 @@ AWSCLI_COPY_OPT="s3 cp"
 AWSCLI_LIST_OPT="s3 ls"
 AWSCLI_DEL_OPT="s3 rm"
 AWSCLIOPT=${AWSCLIOPT:-}
+AWSCLI_ENDPOINT_OPT=${AWSCLI_ENDPOINT_OPT:+"--endpoint-url ${AWSCLI_ENDPOINT_OPT}"}
 
 GCSCLI="/root/google-cloud-sdk/bin/gsutil"
 GCSCLI_COPY_OPT="cp"
@@ -19,12 +20,7 @@ DATE_CMD="/bin/date"
 # arguments: 1. s3 url (s3://.../...)
 s3_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
-	  if [ -z "$AWSCLI_ENDPOINT_OPT" ]
-		then
-			${AWSCLI} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
-		else
-			${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
-		fi
+		${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
 }
 gs_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -34,12 +30,7 @@ gs_exists() {
 # Output the list of the files on specified S3 URL.
 # arguments: 1. s3 url (s3://...)
 s3_list_files() {
-	if [ -z "$AWSCLI_ENDPOINT_OPT" ]
-	then
-		${AWSCLI} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
-	else
-		${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
-	fi
+	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
 }
 gs_list_files() {
 	${GCSCLI} ${GCSCLIOPT} ${GCSCLI_LIST_OPT} $1
@@ -49,12 +40,7 @@ gs_list_files() {
 # arguments: 1. s3 url (s3://.../...)
 s3_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
-		if [ -z "$AWSCLI_ENDPOINT_OPT" ]
-		then
-			${AWSCLI} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
-		else
-			${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
-		fi
+		${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
 }
 gs_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -72,11 +58,7 @@ gs_delete_file() {
 #            2. target s3 url (s3://...)
 s3_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi
-		if [ -z "$AWSCLI_ENDPOINT_OPT" ]
-		then
-			${AWSCLI} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
-		else
-			${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
+		${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
 }
 gs_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -1,6 +1,6 @@
 # default settings
 AWSCLI="/usr/bin/aws"
-AWSCLI_ENDPOINT_URL_OPTION="--endpoint-url https://obs.eu-de.otc.t-systems.com"
+#AWSCLI_ENDPOINT_URL_OPTION="--endpoint-url <YourEndpointUrl>"
 AWSCLI_COPY_OPT="s3 cp"
 AWSCLI_LIST_OPT="s3 ls"
 AWSCLI_DEL_OPT="s3 rm"

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -19,7 +19,12 @@ DATE_CMD="/bin/date"
 # arguments: 1. s3 url (s3://.../...)
 s3_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
-	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
+	  if [ -z "$AWSCLI_ENDPOINT_OPT" ]
+		then
+			${AWSCLI} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
+		else
+			${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
+		fi
 }
 gs_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -29,7 +34,12 @@ gs_exists() {
 # Output the list of the files on specified S3 URL.
 # arguments: 1. s3 url (s3://...)
 s3_list_files() {
-	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
+	if [ -z "$AWSCLI_ENDPOINT_OPT" ]
+	then
+		${AWSCLI} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
+	else
+		${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
+	fi
 }
 gs_list_files() {
 	${GCSCLI} ${GCSCLIOPT} ${GCSCLI_LIST_OPT} $1
@@ -39,7 +49,12 @@ gs_list_files() {
 # arguments: 1. s3 url (s3://.../...)
 s3_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
-	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
+		if [ -z "$AWSCLI_ENDPOINT_OPT" ]
+		then
+			${AWSCLI} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
+		else
+			${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
+		fi
 }
 gs_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -57,7 +72,11 @@ gs_delete_file() {
 #            2. target s3 url (s3://...)
 s3_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi
-	${AWSCLI} ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
+		if [ -z "$AWSCLI_ENDPOINT_OPT" ]
+		then
+			${AWSCLI} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
+		else
+			${AWSCLI} --endpoint-url ${AWSCLI_ENDPOINT_OPT} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
 }
 gs_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -1,5 +1,6 @@
 # default settings
 AWSCLI="/usr/bin/aws"
+AWSCLI_ENDPOINT_URL_OPTION="--endpoint-url https://obs.eu-de.otc.t-systems.com"
 AWSCLI_COPY_OPT="s3 cp"
 AWSCLI_LIST_OPT="s3 ls"
 AWSCLI_DEL_OPT="s3 rm"
@@ -19,7 +20,7 @@ DATE_CMD="/bin/date"
 # arguments: 1. s3 url (s3://.../...)
 s3_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
-	${AWSCLI} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
+	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1 >/dev/null
 }
 gs_exists() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -29,7 +30,7 @@ gs_exists() {
 # Output the list of the files on specified S3 URL.
 # arguments: 1. s3 url (s3://...)
 s3_list_files() {
-	${AWSCLI} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
+	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_LIST_OPT} $1
 }
 gs_list_files() {
 	${GCSCLI} ${GCSCLIOPT} ${GCSCLI_LIST_OPT} $1
@@ -39,7 +40,7 @@ gs_list_files() {
 # arguments: 1. s3 url (s3://.../...)
 s3_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
-	${AWSCLI} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
+	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_DEL_OPT} $1
 }
 gs_delete_file() {
 	if [ $# -ne 1 ]; then return 255; fi
@@ -57,7 +58,7 @@ gs_delete_file() {
 #            2. target s3 url (s3://...)
 s3_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi
-	${AWSCLI} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
+	${AWSCLI} ${AWSCLI_ENDPOINT_URL_OPTION} ${AWSCLIOPT} ${AWSCLI_COPY_OPT} $1 $2
 }
 gs_copy_file() {
 	if [ $# -ne 2 ]; then return 255; fi

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -1,6 +1,5 @@
 # default settings
 AWSCLI="/usr/bin/aws"
-#AWSCLI_ENDPOINT_OPT="--endpoint-url <YourEndpointUrl>"
 AWSCLI_COPY_OPT="s3 cp"
 AWSCLI_LIST_OPT="s3 ls"
 AWSCLI_DEL_OPT="s3 rm"


### PR DESCRIPTION
As mentioned in #27 this is the PR for supporting custom s3 endpoints.
I successfully ran the e2e script for AWS (because noting GCP related was changed).

If you don't set the new env var AWSCLI_ENDPOINT_URL_OPTION the default s3 endpoint will be used.
If you set the var, the provided endpoint will be used. That's it. No rocket science. 😄 

BTW: I updated the README as well.