### PR TITLE
"Unrecognized field 'snapshot'"の解決

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -61,7 +61,7 @@ else
   MONGODUMP_OPTS="-h ${MONGODB_HOST} ${MONGODUMP_OPTS}"
 fi
 echo "dump MongoDB..."
-mongodump -o ${TARGET} ${MONGODUMP_OPTS}
+mongodump -o ${TARGET} ${MONGODUMP_OPTS} --forceTableScan
 
 # run tar command
 echo "backup ${TARGET}..."


### PR DESCRIPTION
https://dba.stackexchange.com/questions/215534/mongodump-unrecognized-field-snapshot

monodoDBのbackupにおいて、エラーが発生していました。
上記のURLを参考に変更したところ、一応動くようになりました。
確認お願いします。