### PR TITLE
Fix/deprecation syntax of ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get SemVer
         run: |
           SEMVER=`git tag | sed -E 's/^v//'`
-          echo ::set-env name=SEMVER::$SEMVER
+          echo "SEMVER=$SEMVER" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v1.0.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     
     - name: Set service account key path
       run: |
-        echo ::set-env name=GCP_SERVICE_ACCOUNT_KEY_JSON_PATH::"$(pwd)/tmp/key.json"
+        echo "GCP_SERVICE_ACCOUNT_KEY_JSON_PATH=$(pwd)/tmp/key.json" >> $GITHUB_ENV
 
     - name: Run integration tests
       run: |


### PR DESCRIPTION
Fix deprecation syntax of CI.

see. https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
